### PR TITLE
Reports update

### DIFF
--- a/src/components/IncomesOutcomesMonthly/IncomesOutcomesMonthly.js
+++ b/src/components/IncomesOutcomesMonthly/IncomesOutcomesMonthly.js
@@ -5,11 +5,11 @@ const IncomesOutcomesMonthly = ({ incomes, outcomes }) => {
     <div className={s.balance_container}>
       <div className={s.outcomes_div}>
         <p className={s.title}>Расходы:</p>
-        <p className={s.outcomes}>{`- ${outcomes} грн.`}</p>
+        <p className={s.outcomes}>{`- ${outcomes?.toFixed(2)} грн.`}</p>
       </div>
       <div className={s.incomes_div}>
         <p className={s.title}>Доходы:</p>
-        <p className={s.incomes}>{`+ ${incomes} грн.`}</p>
+        <p className={s.incomes}>{`+ ${incomes?.toFixed(2)} грн.`}</p>
       </div>
     </div>
   );

--- a/src/components/IncomesOutcomesMonthly/IncomesOutcomesMonthly.js
+++ b/src/components/IncomesOutcomesMonthly/IncomesOutcomesMonthly.js
@@ -5,11 +5,11 @@ const IncomesOutcomesMonthly = ({ incomes, outcomes }) => {
     <div className={s.balance_container}>
       <div className={s.outcomes_div}>
         <p className={s.title}>Расходы:</p>
-        <p className={s.outcomes}>{`- ${outcomes?.toFixed(2)} грн.`}</p>
+        <p className={s.outcomes}>{`- ${outcomes?.toFixed(2) || 0} грн.`}</p>
       </div>
       <div className={s.incomes_div}>
         <p className={s.title}>Доходы:</p>
-        <p className={s.incomes}>{`+ ${incomes?.toFixed(2)} грн.`}</p>
+        <p className={s.incomes}>{`+ ${incomes?.toFixed(2) || 0} грн.`}</p>
       </div>
     </div>
   );

--- a/src/components/MonthSelector/MonthSelector.js
+++ b/src/components/MonthSelector/MonthSelector.js
@@ -17,7 +17,7 @@ const MonthSelector = () => {
   useEffect(() => {
     dispatch(changeReportYear(year));
     dispatch(changeReportMonth(month + 1));
-  }, [dispatch, month, year]);
+  }, []);
 
   function previousMonth() {
     if (month === 0) {
@@ -25,7 +25,7 @@ const MonthSelector = () => {
       setMonth(11);
 
       dispatch(changeReportYear(year - 1));
-      dispatch(changeReportMonth('12'));
+      dispatch(changeReportMonth(12));
     } else {
       setMonth(month - 1);
 
@@ -38,12 +38,12 @@ const MonthSelector = () => {
       setYear(year + 1);
       setMonth(0);
 
-      dispatch(changeReportYear(String(year + 1)));
-      dispatch(changeReportMonth('1'));
+      dispatch(changeReportYear(year + 1));
+      dispatch(changeReportMonth(1));
     } else {
       setMonth(month + 1);
 
-      dispatch(changeReportMonth(String(month + 1)));
+      dispatch(changeReportMonth(month + 1));
     }
   }
 

--- a/src/components/MonthSelector/MonthSelector.js
+++ b/src/components/MonthSelector/MonthSelector.js
@@ -3,10 +3,7 @@ import Icons from '../../Icons';
 import s from './MonthSelector.module.css';
 import { MONTHS } from '../../utils/months';
 import { useDispatch } from 'react-redux';
-import {
-  changeReportMonth,
-  changeReportYear,
-} from '../../redux/reports/reportsSlice';
+import { changeReportDate } from '../../redux/reports/reportsSlice';
 
 const MonthSelector = () => {
   const now = new Date();
@@ -15,8 +12,7 @@ const MonthSelector = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(changeReportYear(year));
-    dispatch(changeReportMonth(month + 1));
+    dispatch(changeReportDate(`${month + 1}-${year}`));
   }, []);
 
   function previousMonth() {
@@ -24,12 +20,11 @@ const MonthSelector = () => {
       setYear(year - 1);
       setMonth(11);
 
-      dispatch(changeReportYear(year - 1));
-      dispatch(changeReportMonth(12));
+      dispatch(changeReportDate(`${12}-${year - 1}`));
     } else {
       setMonth(month - 1);
 
-      dispatch(changeReportMonth(month - 1));
+      dispatch(changeReportDate(`${month}-${year}`));
     }
   }
 
@@ -38,12 +33,11 @@ const MonthSelector = () => {
       setYear(year + 1);
       setMonth(0);
 
-      dispatch(changeReportYear(year + 1));
-      dispatch(changeReportMonth(1));
+      dispatch(changeReportDate(`${1}-${year + 1}`));
     } else {
       setMonth(month + 1);
 
-      dispatch(changeReportMonth(month + 1));
+      dispatch(changeReportDate(`${month + 2}-${year}`));
     }
   }
 

--- a/src/components/MonthSelector/MonthSelector.js
+++ b/src/components/MonthSelector/MonthSelector.js
@@ -45,7 +45,7 @@ const MonthSelector = () => {
     <div className={s.selector_container}>
       <p className={s.selector_title}>Текущий период:</p>
       <div className={s.selector_line}>
-        <div className={s.href} onClick={previousMonth}>
+        <button className={s.selector_toggle_btn} onClick={previousMonth}>
           <Icons
             name="before"
             color="#FF751D"
@@ -53,12 +53,13 @@ const MonthSelector = () => {
             height="12"
             className={s.icon}
           />
+        </button>
+        <div className={s.label}>
+          <span className={s.month}>{MONTHS[month]}</span>
+          <span className={s.year}>{year}</span>
         </div>
 
-        <p className={s.month}>{MONTHS[month]}</p>
-        <p className={s.year}>{year}</p>
-
-        <div className={s.href} onClick={nextMonth}>
+        <button className={s.selector_toggle_btn} onClick={nextMonth}>
           <Icons
             name="after"
             color="#FF751D"
@@ -66,7 +67,7 @@ const MonthSelector = () => {
             height="12"
             className={s.icon}
           />
-        </div>
+        </button>
       </div>
     </div>
   );

--- a/src/components/MonthSelector/MonthSelector.module.css
+++ b/src/components/MonthSelector/MonthSelector.module.css
@@ -2,7 +2,8 @@
 }
 
 .selector_title {
-  font-family: Roboto;
+  margin-bottom: 5px;
+
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
@@ -16,22 +17,32 @@
   justify-content: space-around;
 }
 
+.selector_toggle_btn {
+  padding: 0 10px;
+
+  background-color: transparent;
+  border: none;
+  outline: none;
+  cursor: pointer;
+}
+
+.label {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 110px;
+}
+
 .month,
 .year {
-  font-family: Roboto;
   font-size: 14px;
   font-style: normal;
   font-weight: 700;
   line-height: 16px;
   letter-spacing: 0.02em;
 }
+
 .month {
-  padding-left: 6px;
-  width: 72px;
-  text-align: right;
-}
-.year {
-  padding-left: 6px;
-  padding-right: 6px;
-  width: 44px;
+  margin-right: 5px;
 }

--- a/src/components/Report/Report.js
+++ b/src/components/Report/Report.js
@@ -1,7 +1,8 @@
 import { useSelector } from 'react-redux';
 import { useMediaQuery } from 'react-responsive';
 import {
-  getExpensesTotalSum, getIncomesTotalSum
+  getExpensesTotalSum,
+  getIncomesTotalSum,
 } from '../../redux/reports/reportsSelectors';
 import Balance from '../Balance';
 import { IncomesOutcomesMonthly } from '../IncomesOutcomesMonthly';
@@ -11,8 +12,6 @@ import ReportIncomeExpenses from '../ReportIncomeExpenses';
 import { ReturnHome } from '../ReturnHome';
 import Wrapper from '../Wrapper';
 import s from './Report.module.scss';
-
-
 
 export default function Report() {
   const incomesTotalSum = useSelector(getIncomesTotalSum);

--- a/src/components/ReportIncomeExpenses/ReportIncomeExpenses.js
+++ b/src/components/ReportIncomeExpenses/ReportIncomeExpenses.js
@@ -11,6 +11,8 @@ import {
   getCategoryDataExpense,
   getCategoryDataIncome,
   getReportDate,
+  getTransactionsAllLoading,
+  getTransactionsAllError,
 } from '../../redux/reports/reportsSelectors';
 
 const Chart = ({ chartData }) => {
@@ -43,6 +45,8 @@ export default function ReportIncomeExpenses() {
 
   const categoryDataExpense = useSelector(getCategoryDataExpense);
   const categoryDataIncome = useSelector(getCategoryDataIncome);
+  const isTransactionsLoading = useSelector(getTransactionsAllLoading);
+  const isTransactionsError = useSelector(getTransactionsAllError);
 
   useEffect(() => {
     if (reportDate) dispatch(getTransactionsByDate(reportDate));
@@ -75,6 +79,16 @@ export default function ReportIncomeExpenses() {
     chartData = chartTransactionsDataIncome;
     reportLabel = 'Доходы';
   }
+
+  if (isTransactionsLoading)
+    return <p className={styles.notification}>Загружается...</p>;
+
+  if (isTransactionsError)
+    return (
+      <p className={styles.notification}>
+        Извините, что-то пошло не так... Попробуйте ещё раз позже
+      </p>
+    );
 
   return (
     <div className={styles.container}>

--- a/src/components/ReportIncomeExpenses/ReportIncomeExpenses.js
+++ b/src/components/ReportIncomeExpenses/ReportIncomeExpenses.js
@@ -10,8 +10,7 @@ import { getTransactionsByDate } from '../../redux/reports/reportsOperations';
 import {
   getCategoryDataExpense,
   getCategoryDataIncome,
-  getReportMonth,
-  getReportYear,
+  getReportDate,
 } from '../../redux/reports/reportsSelectors';
 
 const Chart = ({ chartData }) => {
@@ -40,20 +39,14 @@ export default function ReportIncomeExpenses() {
 
   const dispatch = useDispatch();
 
-  const reportMonth = useSelector(getReportMonth);
-  const reportYear = useSelector(getReportYear);
+  const reportDate = useSelector(getReportDate);
 
   const categoryDataExpense = useSelector(getCategoryDataExpense);
   const categoryDataIncome = useSelector(getCategoryDataIncome);
 
   useEffect(() => {
-    let reportDate;
-
-    if (reportMonth && reportYear) {
-      reportDate = `${reportMonth}-${reportYear}`;
-      dispatch(getTransactionsByDate(reportDate));
-    }
-  }, [dispatch, reportMonth, reportYear]);
+    if (reportDate) dispatch(getTransactionsByDate(reportDate));
+  }, [dispatch, reportDate]);
 
   let chartTransactionsDataExpense;
   if (categoryDataExpense) {

--- a/src/components/ReportIncomeExpenses/ReportIncomeExpenses.module.scss
+++ b/src/components/ReportIncomeExpenses/ReportIncomeExpenses.module.scss
@@ -11,3 +11,10 @@
     max-width: 1060px;
   }
 }
+
+.notification {
+  padding-top: 50px;
+  font-size: 24px;
+  font-weight: 700;
+  color: rgba(82, 85, 95, 0.7);
+}

--- a/src/redux/reports/reportsSelectors.js
+++ b/src/redux/reports/reportsSelectors.js
@@ -2,14 +2,12 @@ const getCategoryDataExpense = state => state.reports.transactionsAll.expenses;
 const getCategoryDataIncome = state => state.reports.transactionsAll.incomes;
 const getExpensesTotalSum = state => state.reports.transactionsAll.allExpenses;
 const getIncomesTotalSum = state => state.reports.transactionsAll.allIncomes;
-const getReportMonth = state => state.reports.reportMonth;
-const getReportYear = state => state.reports.reportYear;
+const getReportDate = state => state.reports.reportDate;
 
 export {
   getCategoryDataExpense,
   getCategoryDataIncome,
   getIncomesTotalSum,
   getExpensesTotalSum,
-  getReportMonth,
-  getReportYear,
+  getReportDate,
 };

--- a/src/redux/reports/reportsSelectors.js
+++ b/src/redux/reports/reportsSelectors.js
@@ -3,6 +3,8 @@ const getCategoryDataIncome = state => state.reports.transactionsAll.incomes;
 const getExpensesTotalSum = state => state.reports.transactionsAll.allExpenses;
 const getIncomesTotalSum = state => state.reports.transactionsAll.allIncomes;
 const getReportDate = state => state.reports.reportDate;
+const getTransactionsAllLoading = state => state.reports.transactionsAllLoading;
+const getTransactionsAllError = state => state.reports.transactionsAllError;
 
 export {
   getCategoryDataExpense,
@@ -10,4 +12,6 @@ export {
   getIncomesTotalSum,
   getExpensesTotalSum,
   getReportDate,
+  getTransactionsAllLoading,
+  getTransactionsAllError,
 };

--- a/src/redux/reports/reportsSlice.js
+++ b/src/redux/reports/reportsSlice.js
@@ -3,8 +3,7 @@ import { getTransactionsByDate } from '../reports/reportsOperations';
 
 const initialState = {
   transactionsAll: [],
-  reportMonth: null,
-  reportYear: null,
+  reportDate: null,
   transactionsAllLoading: false,
   transactionsAllError: null,
 };
@@ -13,11 +12,8 @@ const reportsSlice = createSlice({
   name: 'reports',
   initialState,
   reducers: {
-    changeReportMonth: (state, { payload }) => {
-      state.reportMonth = payload;
-    },
-    changeReportYear: (state, { payload }) => {
-      state.reportYear = payload;
+    changeReportDate: (state, { payload }) => {
+      state.reportDate = payload;
     },
   },
   extraReducers: {
@@ -37,6 +33,6 @@ const reportsSlice = createSlice({
   },
 });
 
-export const { changeReportMonth, changeReportYear } = reportsSlice.actions;
+export const { changeReportDate } = reportsSlice.actions;
 
 export default reportsSlice.reducer;


### PR DESCRIPTION
- when choosing a month - for each month only one request to the server (one switch - one request)
- fixed the styles of the month switch - now it looks better and it's easier to get to the toggle buttons (I think this will be especially important on the mobile version)
- notifications about the status of loading reports; if reports are not loaded - "Expenses:" and "Income:" show 0, not undefined